### PR TITLE
settings(webrtc): Add webrtc google meet warning

### DIFF
--- a/settings/webrtc.json
+++ b/settings/webrtc.json
@@ -1,11 +1,11 @@
 [
     {
-        "name": "webrtc", 
-        "type": "boolean", 
-        "initial": true, 
-        "label": "Disable WebRTC", 
-        "help_text": "Disables the WebRTC function, which gives away your local ips. Some addons like uBlock origin provide settings to prevent WebRTC from exposing local ips without disabling WebRTC.",
-        "addons": [], 
+        "name": "webrtc",
+        "type": "boolean",
+        "initial": true,
+        "label": "Disable WebRTC",
+        "help_text": "Disables the WebRTC function, which gives away your local ips. Some addons like uBlock origin provide settings to prevent WebRTC from exposing local ips without disabling WebRTC. This can break google meet camera or microphone access.",
+        "addons": [],
         "config": {
             "media.peerconnection.enabled": false
         }


### PR DESCRIPTION
I am adding a warning on this option since it can break the Google Meet camera and audio function
related to this: https://github.com/allo-/ffprofile/issues/283.